### PR TITLE
dema: fix segmentation fault

### DIFF
--- a/common/config_param.c
+++ b/common/config_param.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <errno.h>
 
 #include "config_param.h"
 #include "config_file.h"
@@ -121,6 +122,10 @@ int CfgParamStr(const char *cfg_file, const char *rparam, char *ret_val, int rsi
     ret = -1;
     /* configuration file is without errors! */
     fp = fopen(cfg_file, "r");
+    if(!fp){
+        LogPrintf(LV_ERROR, "Can not open config file \"%s\": %s!", cfg_file, strerror(errno));
+        return -1;
+    }
     sprintf(scans, "%s=%s", rparam, "%s %s");
     while (fgets(buffer, CFG_LINE_MAX_SIZE, fp) != NULL) {
         /* check if line is a comment */
@@ -183,6 +188,10 @@ int CfgParamInt(const char *cfg_file, const char *rparam, long *rval)
     ret = -1;
     /* configuration file is without errors! */
     fp = fopen(cfg_file, "r");
+    if(!fp){
+        LogPrintf(LV_ERROR, "Can not open config file \"%s\": %s!", cfg_file, strerror(errno));
+        return -1;
+    }
     sprintf(scans, "%s=%s", rparam, "%li %s");
     while (fgets(buffer, CFG_LINE_MAX_SIZE, fp) != NULL) {
         /* check if line is a comment */

--- a/system/dema/dema.c
+++ b/system/dema/dema.c
@@ -32,6 +32,7 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <pthread.h>
+#include <errno.h>
 
 #include "dema.h"
 #include "session_decoding.h"
@@ -600,6 +601,10 @@ int CfgParamStr(const char *cfg_file, const char *rparam, char *ret_val, int rsi
     ret = -1;
     /* configuration file is without errors! */
     fp = fopen(cfg_file, "r");
+    if(!fp){
+        LogPrintf(LV_ERROR, "Can not open config file \"%s\": %s!", cfg_file, strerror(errno));
+        exit(1);
+    }
     sprintf(scans, "%s=%s", rparam, "%s %s");
     while (fgets(buffer, CFG_LINE_MAX_SIZE, fp) != NULL) {
         /* check if line is a comment */

--- a/system/dema/log.c
+++ b/system/dema/log.c
@@ -96,6 +96,14 @@ int LogCfg(char *file_cfg, char *root_dir)
     else {
         sprintf(log_dir, "/tmp");
     }
+    /* dir creation */
+    if (mkdir(log_dir, 0x01FF) == -1 && errno != EEXIST) {
+        printf("error: unable to create dir %s\n", log_dir);
+        return -1;
+    }
+
+    sprintf(log_file, LOG_FILE_TMPL, log_dir, log_name, 1900+time_st_p->tm_year, time_st_p->tm_mon+1, time_st_p->tm_mday);
+
     if (file_cfg != NULL && file_cfg[0] != '\0') {
         if (CfgParamStr(file_cfg, CFG_PAR_ROOT_DIR, dirbase, CFG_LINE_MAX_SIZE) == 0) {
             sprintf(log_dir, "%s/log", dirbase);
@@ -128,13 +136,6 @@ int LogCfg(char *file_cfg, char *root_dir)
             }
         }
     }
-    /* dir creation */
-    if (mkdir(log_dir, 0x01FF) == -1 && errno != EEXIST) {
-        printf("error: unable to create dir %s\n", log_dir);
-        return -1;
-    }
-    
-    sprintf(log_file, LOG_FILE_TMPL, log_dir, log_name, 1900+time_st_p->tm_year, time_st_p->tm_mon+1, time_st_p->tm_mday);
     
     return 0;
 }


### PR DESCRIPTION
DeMa would crash if input a wrong config file, e.g., “$./dema -c
wrong_file" will trigger a segfault.
This patch fixes this by adding error-handling code for fopen in
CfgParamXXX.
I also move the definition of log_file before calling CfgParamStr, so
that LogPrintf can write log successfully.